### PR TITLE
Fix a small error of example config

### DIFF
--- a/config/kubeadm/v1beta3/doc.go
+++ b/config/kubeadm/v1beta3/doc.go
@@ -263,7 +263,7 @@ limitations under the License.
 //       pathType: File
 // scheduler:
 //   extraArgs:
-//     address: "10.100.0.1"
+//     bind-address: "10.100.0.1"
 //   extraVolumes:
 //     - name: "some-volume"
 //       hostPath: "/etc/some-path"


### PR DESCRIPTION
我当初按照kubeadm的文档页面上的示例config,直接起了个集群，然后发现kube scheduler报错说参数不支持。查看了一下是现在把address换成了bind-address。
然后看到kubeadm页面是auto生成的，追溯了一下上游，应该是您这个仓库。
能麻烦通过一下，我再给下游个pr嘛